### PR TITLE
Dashboard fixes v1

### DIFF
--- a/helpers/utils/projections.py
+++ b/helpers/utils/projections.py
@@ -4,17 +4,20 @@ from sklearn.decomposition import PCA
 import streamlit as st
 import plotly.express as px
 
+
 @st.cache
 def perform_pca_projection(X):
     tsne = PCA(n_components=2, random_state=0)
     X_projected = tsne.fit_transform(X)
     return X_projected
 
+
 @st.cache
 def perform_umap_projection(X):
     umap_2d = UMAP(n_components=2, init='random', random_state=0)
     X_projected = umap_2d.fit_transform(X)
     return X_projected
+
 
 @st.cache
 def perform_tsne_projection(X):
@@ -31,13 +34,18 @@ projections_dict = {
 
 
 def plot_scatter(df, incomplete_column, current_null_index):
-    fig = px.scatter(df.sort_values(by=['y_pred']), x="x", y="y",
+    fig = px.scatter(df, x="x", y="y",
                      color=incomplete_column,
                      symbol="y_pred",
-                     #hover_name=target_column,
-                     width=1000, height=800)
-    fig.layout.legend.y = 1
-    fig.layout.legend.x = 1.2
+                     symbol_sequence=["circle", "square", "diamond", "cross", "triangle-up", "triangle-down",
+                                      "pentagon", "circle-cross", "square-cross", "diamond-cross"],
+                     symbol_map={"uncertain": "x"},
+                     text='y_pred',
+                     # hover_name=target_column,
+                     width=1000, height=800
+                     )
+    fig.update_traces(textposition='top center', textfont_size=8, textfont_color="#636363")
+    fig.layout.showlegend = False
     uncertain_x, uncertain_y = df[['x', 'y']].loc[current_null_index]
     add_annotation(fig, uncertain_x, uncertain_y)
     st.plotly_chart(fig)

--- a/helpers/utils/projections.py
+++ b/helpers/utils/projections.py
@@ -46,7 +46,7 @@ def plot_scatter(df, incomplete_column, current_null_index):
                      range_x=[uncertain_x - df['x'].std(), uncertain_x + df['x'].std()],
                      range_y = [uncertain_y - df['y'].std(), uncertain_y + df['y'].std()],
                      # hover_name=target_column,
-                        height=800
+                        height=700
                      )
     fig.update_traces(textposition='top center', textfont_size=8, textfont_color="#636363")
     fig.layout.showlegend = False

--- a/helpers/utils/projections.py
+++ b/helpers/utils/projections.py
@@ -34,6 +34,8 @@ projections_dict = {
 
 
 def plot_scatter(df, incomplete_column, current_null_index):
+    uncertain_x, uncertain_y = df[['x', 'y']].loc[current_null_index]
+
     fig = px.scatter(df, x="x", y="y",
                      color=incomplete_column,
                      symbol="y_pred",
@@ -41,14 +43,15 @@ def plot_scatter(df, incomplete_column, current_null_index):
                                       "pentagon", "circle-cross", "square-cross", "diamond-cross"],
                      symbol_map={"uncertain": "x"},
                      text='y_pred',
+                     range_x=[uncertain_x - df['x'].std(), uncertain_x + df['x'].std()],
+                     range_y = [uncertain_y - df['y'].std(), uncertain_y + df['y'].std()],
                      # hover_name=target_column,
-                     width=1000, height=800
+                        height=800
                      )
     fig.update_traces(textposition='top center', textfont_size=8, textfont_color="#636363")
     fig.layout.showlegend = False
-    uncertain_x, uncertain_y = df[['x', 'y']].loc[current_null_index]
     add_annotation(fig, uncertain_x, uncertain_y)
-    st.plotly_chart(fig)
+    st.plotly_chart(fig, use_container_width=True)
 
 
 def add_annotation(fig, x, y):

--- a/streamlit_app.py
+++ b/streamlit_app.py
@@ -22,8 +22,10 @@ def calculate_y_pred_uncertain(df_incomplete):
     kmeans.fit(X)
     y_pred = kmeans.predict(X)
 
-    uncertain_y_indexes = find_uncertain_y_indexes(X, number_of_clusters)
-    y_pred_uncertain = [int(el) if i not in uncertain_y_indexes else None for i, el in enumerate(y_pred)]
+    uncertain_y_indexes = find_uncertain_y_indexes(X, number_of_clusters, fuzzy_certainty_thres=0.6)
+    incomplete_indexes = df_incomplete[df_incomplete[incomplete_column].isnull()].index.tolist()
+    uncertain_incomplete_y_indexes = set(uncertain_y_indexes).intersection(incomplete_indexes)
+    y_pred_uncertain = [int(el) if i not in uncertain_incomplete_y_indexes else None for i, el in enumerate(y_pred)]
     return X, y_pred_uncertain
 
 
@@ -43,7 +45,7 @@ user_password = st.sidebar.text_input('Password', type="password")
 
 if not validate(user_id) or not user_password == st.secrets['password']:
     '# Please authorize'
-    'Please provide your ID and password in a sidebar inputs.'
+    'Please provide your ID and password in the sidebar inputs.'
 else:
     with open("settings.json", "r") as f:
         settings = json.load(f)

--- a/streamlit_app.py
+++ b/streamlit_app.py
@@ -84,7 +84,10 @@ else:
                                                     incomplete_column,
                                                     na_fraction_selectbox)
         update_session_state(*calculate_y_pred_uncertain(df_incomplete))
-        st.session_state['started'] = True
+        if None not in st.session_state['y_pred_uncertain']:
+            'Sorry, there are no border points to annotate. Choose other dataset or na_fraction.'
+        else:
+            st.session_state['started'] = True
 
     if st.session_state['started']:
         with st.sidebar:
@@ -132,10 +135,9 @@ else:
                 st.session_state['annotated_points'] = 0
                 st.session_state['started'] = False
                 st.session_state['dataset_generation_seed'] = int(time.time())
-
                 st.success('Your answers have been saved')
                 st.balloons()
-                time.sleep(2)
+                time.sleep(1.5)
 
                 st.experimental_rerun()
         except ValueError:

--- a/streamlit_app.py
+++ b/streamlit_app.py
@@ -87,7 +87,8 @@ else:
         st.session_state['started'] = True
 
     if st.session_state['started']:
-        projection_key = st.selectbox('Set projection', projections_dict.keys())
+        with st.sidebar:
+            projection_key = st.selectbox('Set projection', projections_dict.keys())
         try:
             df_incomplete = get_df_incomplete(str(projection_key), st.session_state.X, dataset_settings,
                                               na_fraction_selectbox)
@@ -104,15 +105,15 @@ else:
 
                 df_incomplete.at[current_null_index, 'y_pred'] = 'uncertain'
                 df_to_show = df_incomplete[df_incomplete['y_pred'].notnull()]
-                plot_scatter(df_to_show, incomplete_column, current_null_index)
 
+                plot_scatter(df_to_show, incomplete_column, current_null_index)
                 with st.sidebar:
                     f"Records to be labeled: {len(df_null_indexes)}"
                     st.progress(
                         st.session_state['annotated_points'] / (
                                 st.session_state['annotated_points'] + n_of_points_to_annotate))
-
-                    uncertain_label = st.radio('Select label for uncertain record', cluster_labels)
+                    cluster_labels.sort(key=int)
+                    uncertain_label = st.selectbox('Select label for uncertain record', cluster_labels)
                     if st.button('Submit'):
                         st.session_state['y_pred_uncertain'][current_null_index] = int(uncertain_label)
                         st.session_state['annotated_points'] += 1


### PR DESCRIPTION
Added/ Fixed:
1. Cluster text annotation above the point
2. List in place of radio buttons during cluster selection
3. Longer symbol sequence for multiple clusters
4. Default centering on annotated point +- std
5. Change in selection of points to annotate: only border **NA** points (till now, all border points)
6. Info when no points to annotate
7. Minor visual fixes

FYI @samordakm - global web app runs the code from _streamlit_ branch. It should restart automatically after each change on this branch (single commit or merged PR).